### PR TITLE
fix: handle --policy-path flag [IAC-3212]

### DIFF
--- a/internal/commands/iactest/policy.go
+++ b/internal/commands/iactest/policy.go
@@ -1,0 +1,54 @@
+package iactest
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/rs/zerolog"
+)
+
+// Preserves the original behavior for IaC+ in the CLI, found at:
+// https://github.com/snyk/cli/blob/2051a6d38071a304dbef97784cfeac20c7f56d09/src/cli/commands/test/iac/v2/index.ts#L63
+func GetPolicyFile(policyPathFlag string, rootDir string, logger *zerolog.Logger) string {
+	policyPath, err := getPolicyFileAtPath(rootDir)
+	if err != nil {
+		logger.Debug().Err(err).Msg(".snyk policy not found in current working directory")
+	}
+
+	// --policy-path flag has precedence over the .snyk file in the root directory
+	if policyPathFlag != "" {
+		policyPath2, err := getPolicyFileAtPath(policyPathFlag)
+		if err != nil {
+			logger.Debug().Err(err).Msg(".snyk policy not found using --policy-path flag")
+		} else {
+			logger.Debug().Msgf("Using .snyk policy from --policy-path flag")
+			return policyPath2
+		}
+	}
+
+	if policyPath != "" {
+		logger.Debug().Msgf("Using .snyk policy from current working directory")
+	}
+	return policyPath
+}
+
+func getPolicyFileAtPath(path string) (string, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("error for path %s: %v", path, err)
+	}
+
+	policyPath := filepath.Join(path, ".snyk")
+	if !info.IsDir() {
+		// if the path is a file, use the directory of the file
+		policyPath = filepath.Join(filepath.Dir(path), ".snyk")
+	}
+
+	_, err = os.Stat(policyPath)
+	if err != nil {
+		return "", fmt.Errorf("error getting .snyk at path %s: %v", policyPath, err)
+	}
+
+	return policyPath, nil
+}

--- a/internal/commands/iactest/policy_test.go
+++ b/internal/commands/iactest/policy_test.go
@@ -1,0 +1,64 @@
+package iactest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPolicyFile(t *testing.T) {
+	logger := zerolog.Nop()
+	t.Run("Policy file exists in root dir", func(t *testing.T) {
+		rootDir := t.TempDir()
+		policyFile := ".snyk"
+		createTestFiles(t, rootDir, []string{policyFile})
+
+		result := GetPolicyFile("", rootDir, &logger)
+		assert.Equal(t, filepath.Join(rootDir, policyFile), result)
+	})
+
+	t.Run("Policy file exists in --policy-path", func(t *testing.T) {
+		rootDir := t.TempDir()
+		policyPath := filepath.Join(rootDir, "customDir")
+		policyFile := ".snyk"
+		createTestFiles(t, policyPath, []string{policyFile})
+
+		result := GetPolicyFile(policyPath, rootDir, &logger)
+		assert.Equal(t, filepath.Join(policyPath, policyFile), result)
+	})
+
+	t.Run("Wrong --policy-path fallback to root dir", func(t *testing.T) {
+		rootDir := t.TempDir()
+		policyPath := "wrongPath"
+		policyFile := ".snyk"
+		createTestFiles(t, rootDir, []string{policyFile})
+
+		result := GetPolicyFile(policyPath, rootDir, &logger)
+		assert.Equal(t, filepath.Join(rootDir, policyFile), result)
+	})
+
+	t.Run("Policy file not found", func(t *testing.T) {
+		rootDir := t.TempDir()
+
+		result := GetPolicyFile("", rootDir, &logger)
+		assert.Empty(t, result)
+	})
+}
+
+func createTestFiles(t *testing.T, baseDir string, files []string) {
+	t.Helper()
+	for _, file := range files {
+		fullPath := filepath.Join(baseDir, file)
+		dir := filepath.Dir(fullPath)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("failed to create directories: %v", err)
+		}
+		_, err := os.Create(fullPath)
+		if err != nil {
+			t.Fatalf("failed to create file %s: %v", fullPath, err)
+		}
+	}
+}


### PR DESCRIPTION
Preserves the original behavior for IaC+ in the CLI, found at: https://github.com/snyk/cli/blob/2051a6d38071a304dbef97784cfeac20c7f56d09/src/cli/commands/test/iac/v2/index.ts#L63