### PR TITLE
fix: handle multiple input paths [IAC-3221]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ jobs:
       - checkout
       - prodsec/security_scans:
           mode: auto
+          iac-scan: disabled
 
 workflows:
   version: 2
@@ -39,6 +40,10 @@ workflows:
             - snyk-bot-slack
           channel: iac-plus-alerts
           trusted-branch: main
+          filters:
+            branches:
+              ignore:
+                - main
       - security-scans:
           name: Security Scans
           context:

--- a/internal/commands/iactest/paths.go
+++ b/internal/commands/iactest/paths.go
@@ -1,0 +1,21 @@
+package iactest
+
+import (
+	"slices"
+	"strings"
+)
+
+func DetermineInputPaths(args []string, cwd string) []string {
+	paths := []string{}
+	for _, arg := range args {
+		isCommand := slices.Contains([]string{"iac", "test"}, arg)
+		isFlag := strings.HasPrefix(arg, "-")
+		if !isCommand && !isFlag {
+			paths = append(paths, arg)
+		}
+	}
+	if len(paths) == 0 {
+		paths = append(paths, cwd)
+	}
+	return paths
+}

--- a/internal/commands/iactest/paths_test.go
+++ b/internal/commands/iactest/paths_test.go
@@ -1,0 +1,60 @@
+package iactest
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDetermineInputPaths(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		cwd  string
+		want []string
+	}{
+		{
+			name: "no arguments",
+			args: []string{},
+			cwd:  "/current/directory",
+			want: []string{"/current/directory"},
+		},
+		{
+			name: "only commands",
+			args: []string{"iac", "test"},
+			cwd:  "/current/directory",
+			want: []string{"/current/directory"},
+		},
+		{
+			name: "commands and flags",
+			args: []string{"iac", "test", "-flag"},
+			cwd:  "/current/directory",
+			want: []string{"/current/directory"},
+		},
+		{
+			name: "commands, flags and paths",
+			args: []string{"iac", "test", "-flag", "/path/one", "/path/two"},
+			cwd:  "/current/directory",
+			want: []string{"/path/one", "/path/two"},
+		},
+		{
+			name: "only paths",
+			args: []string{"/path/one", "/path/two"},
+			cwd:  "/current/directory",
+			want: []string{"/path/one", "/path/two"},
+		},
+		{
+			name: "mixed arguments",
+			args: []string{"iac", "/path/one", "-flag", "/path/two"},
+			cwd:  "/current/directory",
+			want: []string{"/path/one", "/path/two"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DetermineInputPaths(tt.args, tt.cwd); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DetermineInputPaths() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`snyk iac test` can take multiple paths as arguments. There is no support for this in `go-application-framework` so we need to extract the paths ourselves.