### PR TITLE
feat: validate flags [IAC-3227]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -139,7 +139,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/skeema/knownhosts v1.3.0 // indirect
 	github.com/snyk/code-client-go v1.11.2 // indirect
-	github.com/snyk/error-catalog-golang-public v0.0.0-20241030160523-0aa643bb7069 // indirect
+	github.com/snyk/error-catalog-golang-public v0.0.0-20250213115103-040fa8e84054 // indirect
 	github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -674,6 +674,8 @@ github.com/snyk/code-client-go v1.11.2 h1:lUAdMvii5sohZoUtLQphCpnFjNO6Pzca01TYVs
 github.com/snyk/code-client-go v1.11.2/go.mod h1:5abu2X6QfITutaCRBE0lWDUwhQjNTi+cHwGj7A/2OkQ=
 github.com/snyk/error-catalog-golang-public v0.0.0-20241030160523-0aa643bb7069 h1:Oj/BJAEMEuBjTAQ72UYB4tR0IZKOB2ZtdDnAnJDL1BM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20241030160523-0aa643bb7069/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
+github.com/snyk/error-catalog-golang-public v0.0.0-20250213115103-040fa8e84054 h1:xZ4IwKD4m+ai+1IhzVIiiQn7i4K38gXXmEqxlQx9LyA=
+github.com/snyk/error-catalog-golang-public v0.0.0-20250213115103-040fa8e84054/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
 github.com/snyk/go-application-framework v0.0.0-20250107154543-11ab9f003b38 h1:b0DdEuZD5o/H246Hj7775IMTYrMR7EvgD36JeC4zSyI=
 github.com/snyk/go-application-framework v0.0.0-20250107154543-11ab9f003b38/go.mod h1:U54yocklt2NHMeIKTNnWzmOgqhy6KvJgFQUqoIXoVio=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530 h1:s9PHNkL6ueYRiAKNfd8OVxlUOqU3qY0VDbgCD1f6WQY=

--- a/internal/commands/iactest/flags.go
+++ b/internal/commands/iactest/flags.go
@@ -1,6 +1,8 @@
 package iactest
 
-import "github.com/spf13/pflag"
+import (
+	"github.com/spf13/pflag"
+)
 
 const (
 	FlagOrg                        = "org"
@@ -11,7 +13,7 @@ const (
 	FlagTargetReference            = "target-reference"
 	FlagTargetName                 = "target-name"
 	FlagRemoteRepoURL              = "remote-repo-url"
-	FlagSynkCloudEnvironment       = "snyk-cloud-environment"
+	FlagSnykCloudEnvironment       = "snyk-cloud-environment"
 	FlagScan                       = "scan"
 	FlagDepthDetection             = "depth-detection"
 	FlagVarFile                    = "var-file"
@@ -30,7 +32,7 @@ func GetIaCTestFlagSet() *pflag.FlagSet {
 
 	flagSet.String(FlagOrg, "", "Specify the Organization ID to run commands tied to a specific Snyk Organization.")
 	flagSet.Int(FlagDepthDetection, 0, "Indicate how many levels of subdirectories to search. Must be a number, 1 or greater; zero (0) is the current directory.")
-	flagSet.String(FlagSynkCloudEnvironment, "", "ID of the Snyk Cloud environment to get context for scan.")
+	flagSet.String(FlagSnykCloudEnvironment, "", "ID of the Snyk Cloud environment to get context for scan.")
 	//nolint:lll // Long flag description
 	flagSet.String(FlagScan, "resource-changes", "Use this dedicated option for Terraform plan scanning modes to control whether the scan analyzes the full final state or the proposed changes only.")
 	flagSet.String(FlagVarFile, "", "Use this option to load a terraform variable definitions file that is located in a different directory from the scanned one.")

--- a/internal/commands/iactest/project_attributes.go
+++ b/internal/commands/iactest/project_attributes.go
@@ -1,0 +1,31 @@
+package iactest
+
+import (
+	"github.com/snyk/go-application-framework/pkg/configuration"
+)
+
+type ProjectAttributes struct {
+	ProjectEnvironment         *string
+	ProjectBusinessCriticality *string
+	ProjectLifecycle           *string
+	ProjectTags                *string
+}
+
+func GetProjectAttributes(config configuration.Configuration) ProjectAttributes {
+	projectAttributes := ProjectAttributes{}
+	// if the flag is not set, we want to pass nil so we don't confuse this with the empty string value used for "unsetting" the flag
+	projectAttributes.ProjectBusinessCriticality = getStringIfSet(config, FlagProjectBusinessCriticality)
+	projectAttributes.ProjectLifecycle = getStringIfSet(config, FlagProjectLifecycle)
+	projectAttributes.ProjectEnvironment = getStringIfSet(config, FlagProjectEnvironment)
+	projectAttributes.ProjectTags = getStringIfSet(config, FlagProjectTags)
+
+	return projectAttributes
+}
+
+func getStringIfSet(config configuration.Configuration, key string) *string {
+	if config.IsSet(key) {
+		v := config.GetString(key)
+		return &v
+	}
+	return nil
+}

--- a/internal/commands/iactest/validate.go
+++ b/internal/commands/iactest/validate.go
@@ -1,0 +1,244 @@
+package iactest
+
+import (
+	"fmt"
+	"github.com/snyk/error-catalog-golang-public/cli"
+	"github.com/snyk/go-application-framework/pkg/configuration"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var (
+	projectAttributesFlags = []string{FlagProjectTags, FlagProjectEnvironment, FlagProjectLifecycle, FlagProjectBusinessCriticality}
+	unsupportedFlagsIaCV2  = []string{FlagSnykCloudEnvironment}
+
+	validOptionsCriticality = map[string]struct{}{
+		"critical": {}, "high": {}, "medium": {}, "low": {}}
+	validOptionsProjectEnv = map[string]struct{}{
+		"frontend": {}, "backend": {}, "internal": {}, "external": {}, "mobile": {}, "saas": {}, "onprem": {}, "hosted": {}, "distributed": {}}
+	validOptionsProjectLifecycle = map[string]struct{}{
+		"production": {}, "development": {}, "sandbox": {}}
+)
+
+const tfVarExt = ".tfvars"
+
+func validateConfig(config configuration.Configuration) error {
+	if config.GetBool(FeatureFlagNewEngine) {
+		err := validateIacV2Config(config)
+		if err != nil {
+			return err
+		}
+	}
+
+	if config.GetBool(FeatureFlagIntegratedExperience) {
+		err := validateIacPlusConfig(config)
+		if err != nil {
+			return err
+		}
+	}
+
+	return validateCommonConfig(config)
+}
+
+func validateIacV2Config(config configuration.Configuration) error {
+	// check unsupported flags for IaC V2
+	err := checkUnsupportedFlags(config, unsupportedFlagsIaCV2)
+	if err != nil {
+		return err
+	}
+
+	// check --report related flags only if --report is true, otherwise flags are ignored
+	if config.GetBool(FlagReport) {
+		err = validateReportConfig(config)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateIacPlusConfig(config configuration.Configuration) error {
+	// check unsupported flags for IaC+
+	return checkUnsupportedFlags(config, projectAttributesFlags)
+}
+
+func validateCommonConfig(config configuration.Configuration) error {
+	if config.IsSet(FlagVarFile) {
+		err := validateVarFile(config)
+		if err != nil {
+			return err
+		}
+	}
+
+	if config.IsSet(FlagSeverityThreshold) {
+		flag := flagWithOptions{
+			name:         FlagSeverityThreshold,
+			allowEmpty:   false,
+			singleChoice: true,
+			validOptions: validOptionsCriticality,
+		}
+		err := validateFlagValue(config, flag)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func checkUnsupportedFlags(config configuration.Configuration, unsupportedFlags []string) error {
+	for _, f := range unsupportedFlags {
+		if config.IsSet(f) {
+			return cli.NewInvalidFlagOptionError(fmt.Sprintf("Unsupported flag %s provided. Run snyk iac test --help for supported flags", f))
+		}
+	}
+	return nil
+}
+
+type flagWithOptions struct {
+	name         string
+	allowEmpty   bool
+	singleChoice bool
+	validOptions map[string]struct{}
+}
+
+/*
+	This validates config flags that only work together with --report:
+
+--project-environment, --project-business-criticality, --project-lifecycle
+--project-tags
+*/
+func validateReportConfig(config configuration.Configuration) error {
+	flags := []flagWithOptions{
+		{
+			name:         FlagProjectEnvironment,
+			allowEmpty:   true,
+			validOptions: validOptionsProjectEnv,
+		},
+		{
+			name:         FlagProjectLifecycle,
+			allowEmpty:   true,
+			validOptions: validOptionsProjectLifecycle,
+		},
+		{
+			name:         FlagProjectBusinessCriticality,
+			allowEmpty:   true,
+			validOptions: validOptionsCriticality,
+		},
+	}
+
+	for _, flag := range flags {
+		// if flag is not set, no need to check it
+		if !config.IsSet(flag.name) {
+			continue
+		}
+
+		// validate the flag's value(s)
+		err := validateFlagValue(config, flag)
+		if err != nil {
+			return err
+		}
+	}
+
+	// tags need to adhere to a specific KEY=VALUE format
+	err := validateTags(config)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+/*
+	Validates a config flag that can only take one of a specific set of values
+
+e.g. --severity-threshold must be one of low, medium, high, critical
+*/
+func validateFlagValue(config configuration.Configuration, flag flagWithOptions) error {
+	rawFlagValue := config.GetString(flag.name)
+	if rawFlagValue == "" && flag.allowEmpty {
+		return nil
+	}
+
+	rawValues := strings.Split(rawFlagValue, ",")
+
+	if len(rawValues) > 1 && flag.singleChoice {
+		errMsg := fmt.Sprintf("Invalid --%s, please use one of %s ", flag.name, strings.Join(getKeys(flag.validOptions), " | "))
+		return cli.NewInvalidFlagOptionError(errMsg)
+	}
+
+	var invalidValues []string
+	for _, v := range rawValues {
+		if _, exists := flag.validOptions[v]; !exists {
+			invalidValues = append(invalidValues, v)
+		}
+	}
+
+	if len(invalidValues) > 0 {
+		errMsg := fmt.Sprintf("%d invalid %s: %v. Possible values are: %v", len(invalidValues), flag.name, strings.Join(invalidValues, ", "), strings.Join(getKeys(flag.validOptions), ", "))
+		if flag.allowEmpty {
+			errMsg += fmt.Sprintf("\nTo clear all existing values, pass no values i.e. %s=", flag.name)
+		}
+		return cli.NewInvalidFlagOptionError(errMsg)
+	}
+
+	return nil
+}
+
+/*
+	This validates the --project-tags config flag
+
+format: KEY=VALUE
+*/
+func validateTags(config configuration.Configuration) error {
+	// no flag is set no need to validate
+	if !config.IsSet(FlagProjectTags) {
+		return nil
+	}
+
+	rawTags := config.GetString(FlagProjectTags)
+	if rawTags == "" {
+		return nil
+	}
+
+	// tags must have a specific KEY=VALUE format
+	tags := strings.Split(rawTags, ",")
+	for _, t := range tags {
+		tagParts := strings.Split(t, "=")
+		if len(tagParts) != 2 {
+			errMsg := fmt.Sprintf("The tag %s does not have an \"=\" separating the key and value. For example: %s=KEY=VALUE", t, FlagProjectTags)
+			errMsg += fmt.Sprintf("\nTo clear all existing values, pass no values i.e. %s=", FlagProjectTags)
+			return cli.NewInvalidFlagOptionError(errMsg)
+		}
+	}
+
+	return nil
+}
+
+func validateVarFile(config configuration.Configuration) error {
+	varFile := config.GetString(FlagVarFile)
+	_, err := os.Stat(varFile)
+
+	if os.IsNotExist(err) {
+		return cli.NewInvalidFlagOptionError(fmt.Sprintf("We were unable to locate a variable definitions file at: %s. The file at the provided path does not exist", varFile))
+	}
+
+	ext := filepath.Ext(varFile)
+	if ext != tfVarExt {
+		errMsg := fmt.Sprintf("Unsupported value %s provided to --%s. Supported values are: %s", varFile, FlagVarFile, tfVarExt)
+		return cli.NewInvalidFlagOptionError(errMsg)
+	}
+
+	return nil
+}
+
+func getKeys(m map[string]struct{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+
+	return keys
+}

--- a/internal/commands/iactest/validate_test.go
+++ b/internal/commands/iactest/validate_test.go
@@ -1,0 +1,493 @@
+package iactest
+
+import (
+	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestValidateFlagValue(t *testing.T) {
+	type testInput struct {
+		config map[string]any
+		flag   flagWithOptions
+	}
+
+	testCases := []struct {
+		in     testInput
+		hasErr bool
+		desc   string
+	}{
+		{
+			in: testInput{
+				config: map[string]any{
+					FlagProjectEnvironment: "backend",
+				},
+				flag: flagWithOptions{
+					name:         FlagProjectEnvironment,
+					validOptions: map[string]struct{}{"backend": {}, "frontend": {}},
+					allowEmpty:   true,
+				},
+			},
+			hasErr: false,
+			desc:   "valid flag",
+		},
+		{
+			in: testInput{
+				config: map[string]any{
+					FlagProjectEnvironment: "backend,backend",
+				},
+				flag: flagWithOptions{
+					name:         FlagProjectEnvironment,
+					validOptions: map[string]struct{}{"backend": {}, "frontend": {}},
+					allowEmpty:   true,
+				},
+			},
+			hasErr: false,
+			desc:   "multiple valid flags",
+		},
+		{
+			in: testInput{
+				config: map[string]any{
+					FlagProjectEnvironment: "",
+				},
+				flag: flagWithOptions{
+					name:         FlagProjectEnvironment,
+					validOptions: map[string]struct{}{"backend": {}, "frontend": {}},
+					allowEmpty:   true,
+				},
+			},
+			hasErr: false,
+			desc:   "valid empty flag",
+		},
+		{
+			in: testInput{
+				config: map[string]any{
+					FlagProjectEnvironment: "",
+				},
+				flag: flagWithOptions{
+					name:         FlagProjectEnvironment,
+					validOptions: map[string]struct{}{"backend": {}, "frontend": {}},
+					allowEmpty:   false,
+				},
+			},
+			hasErr: true,
+			desc:   "invalid empty flag",
+		},
+		{
+			in: testInput{
+				config: map[string]any{
+					FlagProjectEnvironment: "invalid-value",
+				},
+				flag: flagWithOptions{
+					name:         FlagProjectEnvironment,
+					validOptions: map[string]struct{}{"backend": {}, "frontend": {}},
+					allowEmpty:   true,
+				},
+			},
+			hasErr: true,
+			desc:   "invalid flag",
+		},
+		{
+			in: testInput{
+				config: map[string]any{
+					FlagProjectEnvironment: "invalid-value!tc=,",
+				},
+				flag: flagWithOptions{
+					name:         FlagProjectEnvironment,
+					validOptions: map[string]struct{}{"backend": {}, "frontend": {}},
+					allowEmpty:   true,
+				},
+			},
+			hasErr: true,
+			desc:   "invalid flag format",
+		},
+		{
+			in: testInput{
+				config: map[string]any{
+					FlagProjectEnvironment: "backend",
+				},
+				flag: flagWithOptions{
+					name:         FlagProjectEnvironment,
+					validOptions: map[string]struct{}{"backend": {}, "frontend": {}},
+					allowEmpty:   true,
+					singleChoice: true,
+				},
+			},
+			hasErr: false,
+			desc:   "valid flag with single choice",
+		},
+		{
+			in: testInput{
+				config: map[string]any{
+					FlagProjectEnvironment: "backend,frontend",
+				},
+				flag: flagWithOptions{
+					name:         FlagProjectEnvironment,
+					validOptions: map[string]struct{}{"backend": {}, "frontend": {}},
+					allowEmpty:   true,
+					singleChoice: true,
+				},
+			},
+			hasErr: true,
+			desc:   "invalid flag with single choice",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			config := setupMockConfig(tc.in.config)
+
+			err := validateFlagValue(config, tc.in.flag)
+			if tc.hasErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateTags(t *testing.T) {
+	testCases := []struct {
+		in     map[string]any
+		hasErr bool
+		desc   string
+	}{
+		{
+			in:     map[string]any{},
+			hasErr: false,
+			desc:   "no --tags or --project-tags set, no validation needed",
+		},
+		{
+			in: map[string]any{
+				FlagProjectTags: "env=dev,stage=first",
+			},
+			hasErr: false,
+			desc:   "valid --project-tags",
+		},
+		{
+			in: map[string]any{
+				FlagProjectTags: "",
+			},
+			hasErr: false,
+			desc:   "valid empty --tags",
+		},
+		{
+			in: map[string]any{
+				FlagProjectTags: "env=dev,test",
+			},
+			hasErr: true,
+			desc:   "invalid --project-tags",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			config := setupMockConfig(tc.in)
+
+			err := validateTags(config)
+			if tc.hasErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateReportConfig(t *testing.T) {
+	testCases := []struct {
+		in     map[string]any
+		hasErr bool
+		desc   string
+	}{
+		{
+			in: map[string]any{
+				FlagProjectEnvironment: "invalid-env",
+			},
+			hasErr: true,
+			desc:   "invalid --project-environment",
+		},
+		{
+			in: map[string]any{
+				FlagProjectLifecycle: "invalid-lifecycle",
+			},
+			hasErr: true,
+			desc:   "invalid --project-lifecycle",
+		},
+		{
+			in: map[string]any{
+				FlagProjectBusinessCriticality: "invalid-business-criticality",
+			},
+			hasErr: true,
+			desc:   "invalid --project-business-criticality",
+		},
+		{
+			in: map[string]any{
+				FlagProjectTags: "invalid-tags",
+			},
+			hasErr: true,
+			desc:   "invalid --project-tags",
+		},
+		{
+			in: map[string]any{
+				FlagProjectTags:                "env=dev,stage=first",
+				FlagProjectLifecycle:           "production",
+				FlagProjectBusinessCriticality: "critical",
+				FlagProjectEnvironment:         "backend",
+			},
+			hasErr: false,
+			desc:   "valid --report options",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			config := setupMockConfig(tc.in)
+			err := validateReportConfig(config)
+			if tc.hasErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+
+}
+
+func TestValidateIacV2Config(t *testing.T) {
+	testCases := []struct {
+		in     map[string]any
+		hasErr bool
+		desc   string
+	}{
+		{
+			in: map[string]any{
+				FeatureFlagNewEngine:     true,
+				FlagReport:               false,
+				FlagSnykCloudEnvironment: "cloud",
+			},
+			hasErr: true,
+			desc:   "invalid usage of --snyk-cloud-environment with iac v2",
+		},
+		{
+			in: map[string]any{
+				FeatureFlagNewEngine:   true,
+				FlagReport:             true,
+				FlagProjectEnvironment: "backend",
+			},
+			hasErr: false,
+			desc:   "valid config with valid --report options",
+		},
+		{
+			in: map[string]any{
+				FeatureFlagNewEngine:   true,
+				FlagReport:             false,
+				FlagProjectEnvironment: "invalid-env",
+			},
+			hasErr: false,
+			desc:   "valid config without --report, --project-environment is not checked",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			config := setupMockConfig(tc.in)
+
+			err := validateIacV2Config(config)
+			if tc.hasErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateIacPlusConfig(t *testing.T) {
+	testCases := []struct {
+		in     map[string]any
+		hasErr bool
+		desc   string
+	}{
+		{
+			in: map[string]any{
+				FeatureFlagIntegratedExperience: true,
+				FlagProjectEnvironment:          "backend",
+			},
+			hasErr: true,
+			desc:   "invalid usage of --project-environment with iac+",
+		},
+		{
+			in: map[string]any{
+				FeatureFlagIntegratedExperience: true,
+				FlagProjectLifecycle:            "development",
+			},
+			hasErr: true,
+			desc:   "invalid usage of --project-lifecycle with iac+",
+		},
+		{
+			in: map[string]any{
+				FeatureFlagIntegratedExperience: true,
+				FlagReport:                      false,
+				FlagRemoteRepoURL:               "ref",
+			},
+			hasErr: false,
+			desc:   "valid config without --report, --remote-repo-url is not checked",
+		},
+		{
+			in: map[string]any{
+				FeatureFlagIntegratedExperience: true,
+				FlagReport:                      true,
+				FlagRemoteRepoURL:               "ref",
+			},
+			hasErr: false,
+			desc:   "valid config with valid --report options",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			config := setupMockConfig(tc.in)
+
+			err := validateIacPlusConfig(config)
+			if tc.hasErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateConfig(t *testing.T) {
+	testCases := []struct {
+		in     map[string]any
+		hasErr bool
+		desc   string
+	}{
+		{
+			in: map[string]any{
+				FeatureFlagIntegratedExperience: true,
+				FlagProjectEnvironment:          "backend",
+			},
+			hasErr: true,
+			desc:   "invalid usage of --project-environment with iac+",
+		},
+		{
+			in: map[string]any{
+				FeatureFlagIntegratedExperience: true,
+				FlagReport:                      true,
+				FlagRemoteRepoURL:               "ref",
+			},
+			hasErr: false,
+			desc:   "valid config with valid --report options for iac+",
+		},
+		{
+			in: map[string]any{
+				FeatureFlagNewEngine:     true,
+				FlagReport:               false,
+				FlagSnykCloudEnvironment: "cloud",
+			},
+			hasErr: true,
+			desc:   "invalid usage of --snyk-cloud-environment with iac v2",
+		},
+		{
+			in: map[string]any{
+				FeatureFlagNewEngine:   true,
+				FlagReport:             true,
+				FlagProjectEnvironment: "backend",
+			},
+			hasErr: false,
+			desc:   "valid config with valid --report options for iac v2",
+		},
+		{
+			in: map[string]any{
+				FeatureFlagNewEngine: true,
+				FlagVarFile:          "test.txt",
+			},
+			hasErr: true,
+			desc:   "invalid --var-file for iac v2",
+		},
+		{
+			in: map[string]any{
+				FeatureFlagIntegratedExperience: true,
+				FlagVarFile:                     "test.txt",
+			},
+			hasErr: true,
+			desc:   "invalid --var-file for iac+",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			config := setupMockConfig(tc.in)
+
+			err := validateConfig(config)
+			if tc.hasErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateVarFile(t *testing.T) {
+	type input struct {
+		value  string
+		exists bool
+	}
+
+	testCases := []struct {
+		in     input
+		hasErr bool
+		desc   string
+	}{
+		{
+			in:     input{"test.txt", true},
+			hasErr: true,
+			desc:   "invalid --var-file extension",
+		},
+		{
+			in:     input{"test.tfvars", false},
+			hasErr: true,
+			desc:   "invalid --var-file, file does not exist",
+		},
+		{
+			in:     input{"test.tfvars", true},
+			hasErr: false,
+			desc:   "valid --var-file",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			if tc.in.exists {
+				_, err := os.Create(tc.in.value)
+				if err != nil {
+					t.Error(err)
+				}
+				defer os.Remove(tc.in.value)
+			}
+
+			config := setupMockConfig(map[string]any{FlagVarFile: tc.in.value})
+
+			if tc.hasErr {
+				assert.NotNil(t, validateVarFile(config))
+			} else {
+				assert.Nil(t, validateVarFile(config))
+			}
+		})
+	}
+}
+
+func setupMockConfig(flagValues map[string]any) configuration.Configuration {
+	config := configuration.New()
+
+	for key, value := range flagValues {
+		config.Set(key, value)
+	}
+	return config
+}

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -26,16 +26,20 @@ type SnykPlatformClient struct {
 }
 
 type ShareResultsOptions struct {
-	OrgPublicID    string
-	Kind           string
-	Name           string
-	Branch         string
-	CommitSha      string
-	RunID          string
-	SourceURI      string
-	SourceType     string
-	ProjectID      string
-	AllowAnalytics bool
+	OrgPublicID                string
+	Kind                       string
+	Name                       string
+	Branch                     string
+	CommitSha                  string
+	RunID                      string
+	SourceURI                  string
+	SourceType                 string
+	ProjectID                  string
+	ProjectEnvironment         *string
+	ProjectBusinessCriticality *string
+	ProjectLifecycle           *string
+	ProjectTags                *string
+	AllowAnalytics             bool
 }
 
 type ShareResultsOutput struct {
@@ -97,14 +101,18 @@ func (p *SnykPlatformClient) ShareResults(ctx context.Context, engineResults *en
 
 func (p *SnykPlatformClient) ShareResultsRegistry(ctx context.Context, engineResults *results.Results, opts ShareResultsOptions, policy string) (*ShareResultsOutput, error) {
 	shareResults := &legacy.ShareResults{
-		RegistryClient: p.RegistryClient,
-		AllowAnalytics: opts.AllowAnalytics,
-		Policy:         policy,
-		ProjectName:    opts.Name,
-		RemoteRepoUrl:  opts.SourceURI,
-		GetWd:          os.Getwd,
-		GetRepoRootDir: git.GetRepoRootDir,
-		GetOriginUrl:   git.GetOriginUrl,
+		RegistryClient:             p.RegistryClient,
+		AllowAnalytics:             opts.AllowAnalytics,
+		Policy:                     policy,
+		ProjectName:                opts.Name,
+		RemoteRepoUrl:              opts.SourceURI,
+		GetWd:                      os.Getwd,
+		GetRepoRootDir:             git.GetRepoRootDir,
+		GetOriginUrl:               git.GetOriginUrl,
+		ProjectEnvironment:         opts.ProjectEnvironment,
+		ProjectBusinessCriticality: opts.ProjectBusinessCriticality,
+		ProjectLifecycle:           opts.ProjectLifecycle,
+		ProjectTags:                opts.ProjectTags,
 	}
 
 	response, err := shareResults.ShareResults(engineResults)

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -30,6 +30,10 @@ type ResultsProcessor struct {
 	SeverityThreshold            string
 	TargetReference              string
 	TargetName                   string
+	ProjectEnvironment           *string
+	ProjectBusinessCriticality   *string
+	ProjectLifecycle             *string
+	ProjectTags                  *string
 	RemoteRepoUrl                string
 	GetWd                        func() (string, error)
 	GetRepoRootDir               func(string) (string, error)
@@ -90,13 +94,17 @@ func (p *ResultsProcessor) ProcessResults(rawResults *engine.Results, scanAnalyt
 		p.Logger.Info().Msgf("share results: source URI = %v", sourceURI)
 
 		opts := platform.ShareResultsOptions{
-			OrgPublicID:    userSettings.OrgPublicID,
-			Kind:           "cli",
-			Name:           projectName,
-			Branch:         p.TargetReference,
-			SourceURI:      sourceURI,
-			SourceType:     "cli",
-			AllowAnalytics: p.AllowAnalytics,
+			OrgPublicID:                userSettings.OrgPublicID,
+			Kind:                       "cli",
+			Name:                       projectName,
+			Branch:                     p.TargetReference,
+			SourceURI:                  sourceURI,
+			SourceType:                 "cli",
+			AllowAnalytics:             p.AllowAnalytics,
+			ProjectEnvironment:         p.ProjectEnvironment,
+			ProjectBusinessCriticality: p.ProjectBusinessCriticality,
+			ProjectLifecycle:           p.ProjectLifecycle,
+			ProjectTags:                p.ProjectTags,
 		}
 
 		if p.IacNewEngine {


### PR DESCRIPTION
Validates flags & sends project attributes & tags info to `iac-cli-share-results` in Registry with --report.

Project attributes are: 
- project environment
- project lifecycle
- project business criticality 
- project tags

Validation rules derived from `snyk iac test help` implemented in the PR:

Iac+:
- unsupported flags: --project-environment, --project-lifecycle, --project-business-criticality, --project-tags and --tags
- following flags are supported only if --report is used: --remote-repo-url, --target-reference, --target-name

IaC V2:
- unsupported flags: --snyk-cloud-environment
- following flags are supported only if --report is used: --remote-repo-url, --target-reference, --target-name, --project-environment, --project-lifecycle, --project-business-criticality, --project-tags and --tags

Common flags supported for both IaC+ & IaC V2: --severity-threshold, --var-file

Flag values validations:
--project-environment: "frontend", "backend", "internal", "external",, "mobile", "saas", "onprem", "hosted", "distributed"
--project-lifecycle:  "production", "development", "sandbox"
--project-business-criticality:  "critical", "high", "medium", "low"
--project-tags: format KEY=VALUE
--severity-threshold: "critical", "high", "medium", "low" (single choice)
--var-file: valid file path with .tfvars extension

Jira ticket: https://snyksec.atlassian.net/browse/IAC-3227