### PR TITLE
feat: completed is shown only on successful scan [IAC-3227]

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -61,7 +61,7 @@ type Command struct {
 }
 
 func (c Command) Run() int {
-	if err := c.RunWithError(); err != nil {
+	if _, err := c.RunWithError(); err != nil {
 		c.Logger.Error().Err(err).Send()
 		return 1
 	}
@@ -69,8 +69,21 @@ func (c Command) Run() int {
 	return 0
 }
 
-func (c Command) RunWithError() error {
-	return c.print(c.scan())
+func (c Command) RunWithError() (bool, error) {
+	output := c.scan()
+	isSuccessful := false
+	if len(output.scanErrors) == 0 {
+		isSuccessful = true
+	}
+
+	err := c.print(c.scan())
+	if err != nil {
+		return isSuccessful, err
+	}
+
+	isSuccessful = false
+
+	return isSuccessful, nil
 }
 
 func (c Command) scan() scanOutput {

--- a/internal/commands/iactest/iactest.go
+++ b/internal/commands/iactest/iactest.go
@@ -95,9 +95,13 @@ func runNewEngine(ictx workflow.InvocationContext, inputPaths []string, cwd stri
 	})
 	ui.DisplayTitle()
 	ui.StartProgressBar()
+
+	successful := true
 	defer func() {
 		ui.ClearProgressBar()
-		ui.DisplayCompleted()
+		if successful {
+			ui.DisplayCompleted()
+		}
 	}()
 
 	httpClient := ictx.GetNetworkAccess().GetHttpClient()
@@ -192,7 +196,8 @@ func runNewEngine(ictx workflow.InvocationContext, inputPaths []string, cwd stri
 		IacNewEngine:            config.GetBool(FeatureFlagNewEngine),
 	}
 
-	if err := cmd.RunWithError(); err != nil {
+	successful, err := cmd.RunWithError()
+	if err != nil {
 		// TODO: proper error message
 		return "", fmt.Errorf("error running snyk-iac-test: %v", err)
 	}


### PR DESCRIPTION
Because of:

```
defer func() {
		ui.ClearProgressBar()
		ui.DisplayCompleted()
	}()
```

the `✔ Test completed.` text was shown even if the flow had errors. 

This PR fixes this which makes the extension's behaviour consistent with its legacy counterpart.
