### PR TITLE
feat: add source location in registry share results [IAC-3237]

### DIFF
--- a/internal/processor/legacy/envelope.go
+++ b/internal/processor/legacy/envelope.go
@@ -79,6 +79,7 @@ func convertVulnerabilityToFinding(vulnerability results.Vulnerability) registry
 				},
 				ResourcePath: vulnerability.Resource.FormattedPath,
 				LineNumber:   vulnerability.Resource.Line,
+				ColumnNumber: vulnerability.Resource.Column,
 			},
 		},
 		Type: "iacIssue",
@@ -90,6 +91,17 @@ func convertVulnerabilityToFinding(vulnerability results.Vulnerability) registry
 		// other metadata fields could be added too if needed for UI filtering: category, labels
 		finding.Data.Metadata.Controls = vulnerability.Rule.Controls
 	}
+
+	// add location trace for the resource
+	var locations []registry.Location
+	for _, l := range vulnerability.Resource.SourceLocation {
+		locations = append(locations, registry.Location{
+			LineNumber:   l.Line,
+			ColumnNumber: l.Column,
+			File:         l.File,
+		})
+	}
+	finding.Data.IssueMetadata.SourceLocation = locations
 
 	return finding
 }

--- a/internal/processor/legacy/envelope_test.go
+++ b/internal/processor/legacy/envelope_test.go
@@ -40,7 +40,14 @@ func TestConvertResultsToEnvelopeScanResult(t *testing.T) {
 							Kind:          "terraformconfig",
 							File:          "resource-file",
 							Line:          41,
-							Column:        42,
+							Column:        22,
+							SourceLocation: []results.Location{
+								{
+									Line:   41,
+									Column: 22,
+									File:   "resource-file",
+								},
+							},
 						},
 						{
 							ID:            "second-resource.id",
@@ -49,8 +56,20 @@ func TestConvertResultsToEnvelopeScanResult(t *testing.T) {
 							FormattedPath: "second-resource.resource[id].attribute.nested_attribute",
 							Kind:          "terraformconfig",
 							File:          "resource-file",
-							Line:          41,
-							Column:        42,
+							Line:          1,
+							Column:        2,
+							SourceLocation: []results.Location{
+								{
+									Line:   1,
+									Column: 2,
+									File:   "resource-file",
+								},
+								{
+									Line:   10,
+									Column: 42,
+									File:   "main-file",
+								},
+							},
 						},
 						{
 							ID:            "another-resource.id",
@@ -59,8 +78,15 @@ func TestConvertResultsToEnvelopeScanResult(t *testing.T) {
 							FormattedPath: "another-resource.resource[id].attribute.nested_attribute",
 							Kind:          "terraformconfig",
 							File:          "another-resource-file",
-							Line:          41,
-							Column:        42,
+							Line:          2,
+							Column:        2,
+							SourceLocation: []results.Location{
+								{
+									Line:   2,
+									Column: 2,
+									File:   "another-resource-file",
+								},
+							},
 						},
 					},
 					Vulnerabilities: []results.Vulnerability{
@@ -84,8 +110,15 @@ func TestConvertResultsToEnvelopeScanResult(t *testing.T) {
 								FormattedPath: "first-resource.resource[id].attribute.nested_attribute",
 								File:          "resource-file",
 								Kind:          "terraformconfig",
-								Line:          1,
-								Column:        2,
+								Line:          41,
+								Column:        22,
+								SourceLocation: []results.Location{
+									{
+										Line:   41,
+										Column: 22,
+										File:   "resource-file",
+									},
+								},
 							},
 						},
 						{
@@ -110,6 +143,18 @@ func TestConvertResultsToEnvelopeScanResult(t *testing.T) {
 								Kind:          "terraformconfig",
 								Line:          1,
 								Column:        2,
+								SourceLocation: []results.Location{
+									{
+										Line:   1,
+										Column: 2,
+										File:   "resource-file",
+									},
+									{
+										Line:   10,
+										Column: 42,
+										File:   "main-file",
+									},
+								},
 							},
 						},
 						{
@@ -134,6 +179,13 @@ func TestConvertResultsToEnvelopeScanResult(t *testing.T) {
 								Kind:          "terraformconfig",
 								Line:          2,
 								Column:        2,
+								SourceLocation: []results.Location{
+									{
+										Line:   2,
+										Column: 2,
+										File:   "another-resource-file",
+									},
+								},
 							},
 						},
 					},
@@ -167,7 +219,15 @@ func TestConvertResultsToEnvelopeScanResult(t *testing.T) {
 									Type: "first-resource-type",
 								},
 								ResourcePath: "first-resource.resource[id].attribute.nested_attribute",
-								LineNumber:   1,
+								LineNumber:   41,
+								ColumnNumber: 22,
+								SourceLocation: []registry.Location{
+									{
+										LineNumber:   41,
+										ColumnNumber: 22,
+										File:         "resource-file",
+									},
+								},
 							},
 						},
 						Type: "iacIssue",
@@ -191,6 +251,19 @@ func TestConvertResultsToEnvelopeScanResult(t *testing.T) {
 								},
 								ResourcePath: "second-resource.resource[id].attribute.nested_attribute",
 								LineNumber:   1,
+								ColumnNumber: 2,
+								SourceLocation: []registry.Location{
+									{
+										LineNumber:   1,
+										ColumnNumber: 2,
+										File:         "resource-file",
+									},
+									{
+										LineNumber:   10,
+										ColumnNumber: 42,
+										File:         "main-file",
+									},
+								},
 							},
 						},
 						Type: "iacIssue",
@@ -214,6 +287,14 @@ func TestConvertResultsToEnvelopeScanResult(t *testing.T) {
 								},
 								ResourcePath: "another-resource.resource[id].attribute.nested_attribute",
 								LineNumber:   2,
+								ColumnNumber: 2,
+								SourceLocation: []registry.Location{
+									{
+										LineNumber:   2,
+										ColumnNumber: 2,
+										File:         "another-resource-file",
+									},
+								},
 							},
 						},
 						Type: "iacIssue",
@@ -242,8 +323,15 @@ func TestConvertResultsToEnvelopeScanResult(t *testing.T) {
 							FormattedPath: "first-resource.resource[id].attribute.nested_attribute",
 							Kind:          "terraformconfig",
 							File:          "resource-file",
-							Line:          41,
-							Column:        42,
+							Line:          1,
+							Column:        2,
+							SourceLocation: []results.Location{
+								{
+									File:   "resource-file",
+									Line:   1,
+									Column: 2,
+								},
+							},
 						},
 						{
 							ID:            "second-resource.id",
@@ -252,8 +340,15 @@ func TestConvertResultsToEnvelopeScanResult(t *testing.T) {
 							FormattedPath: "second-resource.resource[id].attribute.nested_attribute",
 							Kind:          "terraformconfig",
 							File:          "resource-file",
-							Line:          41,
-							Column:        42,
+							Line:          1,
+							Column:        2,
+							SourceLocation: []results.Location{
+								{
+									File:   "resource-file",
+									Line:   1,
+									Column: 2,
+								},
+							},
 						},
 						{
 							ID:            "another-resource.id",
@@ -262,8 +357,15 @@ func TestConvertResultsToEnvelopeScanResult(t *testing.T) {
 							FormattedPath: "another-resource.resource[id].attribute.nested_attribute",
 							Kind:          "terraformconfig",
 							File:          "another-resource-file",
-							Line:          41,
-							Column:        42,
+							Line:          2,
+							Column:        2,
+							SourceLocation: []results.Location{
+								{
+									File:   "another-resource-file",
+									Line:   2,
+									Column: 2,
+								},
+							},
 						},
 					},
 					Vulnerabilities: []results.Vulnerability{
@@ -289,6 +391,13 @@ func TestConvertResultsToEnvelopeScanResult(t *testing.T) {
 								Kind:          "terraformconfig",
 								Line:          1,
 								Column:        2,
+								SourceLocation: []results.Location{
+									{
+										File:   "resource-file",
+										Line:   1,
+										Column: 2,
+									},
+								},
 							},
 						},
 						{
@@ -313,6 +422,13 @@ func TestConvertResultsToEnvelopeScanResult(t *testing.T) {
 								Kind:          "terraformconfig",
 								Line:          1,
 								Column:        2,
+								SourceLocation: []results.Location{
+									{
+										File:   "resource-file",
+										Line:   1,
+										Column: 2,
+									},
+								},
 							},
 						},
 						{
@@ -337,6 +453,13 @@ func TestConvertResultsToEnvelopeScanResult(t *testing.T) {
 								Kind:          "terraformconfig",
 								Line:          2,
 								Column:        2,
+								SourceLocation: []results.Location{
+									{
+										File:   "another-resource-file",
+										Line:   2,
+										Column: 2,
+									},
+								},
 							},
 						},
 					},
@@ -371,6 +494,14 @@ func TestConvertResultsToEnvelopeScanResult(t *testing.T) {
 								},
 								ResourcePath: "first-resource.resource[id].attribute.nested_attribute",
 								LineNumber:   1,
+								ColumnNumber: 2,
+								SourceLocation: []registry.Location{
+									{
+										LineNumber:   1,
+										ColumnNumber: 2,
+										File:         "resource-file",
+									},
+								},
 							},
 						},
 						Type: "iacIssue",
@@ -394,6 +525,14 @@ func TestConvertResultsToEnvelopeScanResult(t *testing.T) {
 								},
 								ResourcePath: "second-resource.resource[id].attribute.nested_attribute",
 								LineNumber:   1,
+								ColumnNumber: 2,
+								SourceLocation: []registry.Location{
+									{
+										LineNumber:   1,
+										ColumnNumber: 2,
+										File:         "resource-file",
+									},
+								},
 							},
 						},
 						Type: "iacIssue",
@@ -417,6 +556,14 @@ func TestConvertResultsToEnvelopeScanResult(t *testing.T) {
 								},
 								ResourcePath: "another-resource.resource[id].attribute.nested_attribute",
 								LineNumber:   2,
+								ColumnNumber: 2,
+								SourceLocation: []registry.Location{
+									{
+										LineNumber:   2,
+										ColumnNumber: 2,
+										File:         "another-resource-file",
+									},
+								},
 							},
 						},
 						Type: "iacIssue",
@@ -445,6 +592,13 @@ func TestConvertResultsToEnvelopeScanResult(t *testing.T) {
 							File:          "resource-file",
 							Line:          41,
 							Column:        42,
+							SourceLocation: []results.Location{
+								{
+									File:   "resource-file",
+									Line:   41,
+									Column: 42,
+								},
+							},
 						},
 						{
 							ID:            "second-resource.id",
@@ -455,6 +609,13 @@ func TestConvertResultsToEnvelopeScanResult(t *testing.T) {
 							File:          "resource-file",
 							Line:          41,
 							Column:        42,
+							SourceLocation: []results.Location{
+								{
+									File:   "resource-file",
+									Line:   41,
+									Column: 42,
+								},
+							},
 						},
 						{
 							ID:            "another-resource.id",
@@ -463,8 +624,15 @@ func TestConvertResultsToEnvelopeScanResult(t *testing.T) {
 							FormattedPath: "another-resource.resource[id].attribute.nested_attribute",
 							Kind:          "terraformconfig",
 							File:          "another-resource-file",
-							Line:          41,
-							Column:        42,
+							Line:          2,
+							Column:        2,
+							SourceLocation: []results.Location{
+								{
+									File:   "another-resource-file",
+									Line:   2,
+									Column: 2,
+								},
+							},
 						},
 					},
 					Vulnerabilities: []results.Vulnerability{
@@ -488,8 +656,15 @@ func TestConvertResultsToEnvelopeScanResult(t *testing.T) {
 								FormattedPath: "first-resource.resource[id].attribute.nested_attribute",
 								File:          "resource-file",
 								Kind:          "terraformconfig",
-								Line:          1,
-								Column:        2,
+								Line:          41,
+								Column:        42,
+								SourceLocation: []results.Location{
+									{
+										File:   "resource-file",
+										Line:   41,
+										Column: 42,
+									},
+								},
 							},
 						},
 						{
@@ -512,8 +687,15 @@ func TestConvertResultsToEnvelopeScanResult(t *testing.T) {
 								FormattedPath: "second-resource.resource[id].attribute.nested_attribute",
 								File:          "resource-file",
 								Kind:          "terraformconfig",
-								Line:          1,
-								Column:        2,
+								Line:          41,
+								Column:        42,
+								SourceLocation: []results.Location{
+									{
+										File:   "resource-file",
+										Line:   41,
+										Column: 42,
+									},
+								},
 							},
 						},
 						{
@@ -538,6 +720,13 @@ func TestConvertResultsToEnvelopeScanResult(t *testing.T) {
 								Kind:          "terraformconfig",
 								Line:          2,
 								Column:        2,
+								SourceLocation: []results.Location{
+									{
+										Line:   2,
+										File:   "another-resource-file",
+										Column: 2,
+									},
+								},
 							},
 						},
 					},
@@ -572,7 +761,15 @@ func TestConvertResultsToEnvelopeScanResult(t *testing.T) {
 									Type: "first-resource-type",
 								},
 								ResourcePath: "first-resource.resource[id].attribute.nested_attribute",
-								LineNumber:   1,
+								LineNumber:   41,
+								ColumnNumber: 42,
+								SourceLocation: []registry.Location{
+									{
+										File:         "resource-file",
+										LineNumber:   41,
+										ColumnNumber: 42,
+									},
+								},
 							},
 						},
 						Type: "iacIssue",
@@ -595,7 +792,15 @@ func TestConvertResultsToEnvelopeScanResult(t *testing.T) {
 									Type: "second-resource-type",
 								},
 								ResourcePath: "second-resource.resource[id].attribute.nested_attribute",
-								LineNumber:   1,
+								LineNumber:   41,
+								ColumnNumber: 42,
+								SourceLocation: []registry.Location{
+									{
+										File:         "resource-file",
+										LineNumber:   41,
+										ColumnNumber: 42,
+									},
+								},
 							},
 						},
 						Type: "iacIssue",
@@ -619,6 +824,14 @@ func TestConvertResultsToEnvelopeScanResult(t *testing.T) {
 								},
 								ResourcePath: "another-resource.resource[id].attribute.nested_attribute",
 								LineNumber:   2,
+								ColumnNumber: 2,
+								SourceLocation: []registry.Location{
+									{
+										File:         "another-resource-file",
+										LineNumber:   2,
+										ColumnNumber: 2,
+									},
+								},
 							},
 						},
 						Type: "iacIssue",

--- a/internal/registry/share_results.go
+++ b/internal/registry/share_results.go
@@ -4,9 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"net/http"
-
 	"github.com/snyk/cli-extension-iac/internal/git"
+	"net/http"
 )
 
 func (c *Client) ShareResults(req ShareResultsRequest) (ShareResultsResponse, error) {
@@ -102,12 +101,20 @@ type ResourceInfo struct {
 	Tags map[string]string `json:"tags,omitempty"`
 }
 
+type Location struct {
+	File         string `json:"file"`
+	LineNumber   int    `json:"lineNumber"`
+	ColumnNumber int    `json:"columnNumber"`
+}
+
 type IssueMetadata struct {
-	Type         string       `json:"type,omitempty"`
-	File         string       `json:"file"`
-	ResourcePath string       `json:"resourcePath"`
-	ResourceInfo ResourceInfo `json:"resourceInfo,omitempty"`
-	LineNumber   int          `json:"lineNumber"`
+	Type           string       `json:"type,omitempty"`
+	File           string       `json:"file"`
+	ResourcePath   string       `json:"resourcePath"`
+	ResourceInfo   ResourceInfo `json:"resourceInfo,omitempty"`
+	LineNumber     int          `json:"lineNumber"`
+	ColumnNumber   int          `json:"columnNumber"`
+	SourceLocation []Location   `json:"sourceLocation,omitempty"`
 }
 
 type Finding struct {

--- a/internal/results/results_test.go
+++ b/internal/results/results_test.go
@@ -108,6 +108,18 @@ func TestResultsVulnerabilities(t *testing.T) {
 						File:          "attribute-file",
 						Line:          3,
 						Column:        4,
+						SourceLocation: []results.Location{
+							{
+								File:   "attribute-file",
+								Line:   3,
+								Column: 4,
+							},
+							{
+								File:   "resource-file",
+								Line:   1,
+								Column: 2,
+							},
+						},
 					},
 				},
 			},
@@ -173,6 +185,13 @@ func TestResultsVulnerabilities(t *testing.T) {
 						File:          "resource-file",
 						Line:          1,
 						Column:        2,
+						SourceLocation: []results.Location{
+							{
+								File:   "resource-file",
+								Line:   1,
+								Column: 2,
+							},
+						},
 					},
 				},
 			},
@@ -366,6 +385,13 @@ func TestResultsVulnerabilities(t *testing.T) {
 						File:          "resource-file",
 						Line:          1,
 						Column:        2,
+						SourceLocation: []results.Location{
+							{
+								File:   "resource-file",
+								Line:   1,
+								Column: 2,
+							},
+						},
 					},
 				},
 				{
@@ -379,6 +405,13 @@ func TestResultsVulnerabilities(t *testing.T) {
 						File:          "other-resource-file",
 						Line:          10,
 						Column:        20,
+						SourceLocation: []results.Location{
+							{
+								File:   "other-resource-file",
+								Line:   10,
+								Column: 20,
+							},
+						},
 					},
 				},
 			},
@@ -448,6 +481,13 @@ func TestResultsVulnerabilities(t *testing.T) {
 						Kind:          "input-type",
 						Line:          1,
 						Column:        2,
+						SourceLocation: []results.Location{
+							{
+								File:   "resource-file",
+								Line:   1,
+								Column: 2,
+							},
+						},
 						Tags: map[string]string{
 							"test":   "value",
 							"team":   "iac",
@@ -594,6 +634,18 @@ func TestResultsPassedVulnerabilities(t *testing.T) {
 						File:          "attribute-file",
 						Line:          3,
 						Column:        4,
+						SourceLocation: []results.Location{
+							{
+								File:   "attribute-file",
+								Line:   3,
+								Column: 4,
+							},
+							{
+								File:   "resource-file",
+								Line:   1,
+								Column: 2,
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
Adds column_number & source_location to the registry share results payload (used in --report).
source_location identifies the trace/reachability of the resource for which an issue is detected.

Related PRs: 
- IaC service migration: https://github.com/snyk/iac-service/pull/17
- Registry Monitor Iac Issue model update: https://github.com/snyk/registry/pull/39632

Jira ticket: https://snyksec.atlassian.net/browse/IAC-3237