### PR TITLE
fix: properly use org if passed to share results to [IAC-3276]

### DIFF
--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -115,7 +115,7 @@ func (p *SnykPlatformClient) ShareResultsRegistry(ctx context.Context, engineRes
 		ProjectTags:                opts.ProjectTags,
 	}
 
-	response, err := shareResults.ShareResults(engineResults)
+	response, err := shareResults.ShareResults(engineResults, opts.OrgPublicID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to share scan results: %v", err)
 	}

--- a/internal/processor/legacy/share_results.go
+++ b/internal/processor/legacy/share_results.go
@@ -32,7 +32,7 @@ type ShareResults struct {
 	GetOriginUrl               func(string) (string, error)
 }
 
-func (p *ShareResults) ShareResults(scanResults *results.Results) (registry.ShareResultsResponse, error) {
+func (p *ShareResults) ShareResults(scanResults *results.Results, orgPublicID string) (registry.ShareResultsResponse, error) {
 	contributors, err := p.listContributors()
 	if err != nil {
 		return nil, fmt.Errorf("list contributors: %v", err)
@@ -51,6 +51,7 @@ func (p *ShareResults) ShareResults(scanResults *results.Results) (registry.Shar
 		ScanResults:  []registry.ScanResult{p.convertResultsToEnvelopeScanResult(*scanResults, p.ProjectName, p.Policy)},
 		Contributors: contributors,
 		Attributes:   &attributes,
+		Org:          orgPublicID,
 	}
 
 	if len(tags) != 0 {


### PR DESCRIPTION
## What this does
IaC V2 only.

Fixed a bug in which we could not share results to the desired org when --org=<ORG_ID> parameter was used (or SNYK_ORG=<ORG_ID>).

We always shared results to the preferred organization.

## More information
[Jira ticket IAC-3276](https://snyksec.atlassian.net/browse/IAC-3276)