### PR TITLE
fix: pass target name in registry share results [IAC-3284]

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -76,7 +76,7 @@ func (c Command) RunWithError() (bool, error) {
 		isSuccessful = true
 	}
 
-	err := c.print(c.scan())
+	err := c.print(output)
 	if err != nil {
 		return isSuccessful, err
 	}

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -113,6 +113,7 @@ func (p *SnykPlatformClient) ShareResultsRegistry(ctx context.Context, engineRes
 		ProjectBusinessCriticality: opts.ProjectBusinessCriticality,
 		ProjectLifecycle:           opts.ProjectLifecycle,
 		ProjectTags:                opts.ProjectTags,
+		TargetReference:            opts.Branch,
 	}
 
 	response, err := shareResults.ShareResults(engineResults, opts.OrgPublicID)

--- a/internal/processor/legacy/envelope.go
+++ b/internal/processor/legacy/envelope.go
@@ -57,6 +57,7 @@ func (p *ShareResults) getTarget(projectName string) registry.Target {
 
 	return registry.Target{
 		RemoteUrl: formattedOriginUrl,
+		Name:      projectName,
 	}
 }
 

--- a/internal/processor/legacy/envelope_test.go
+++ b/internal/processor/legacy/envelope_test.go
@@ -571,6 +571,7 @@ func TestConvertResultsToEnvelopeScanResult(t *testing.T) {
 				},
 				Target: registry.Target{
 					RemoteUrl: "http://github.com/test/remote-repo-url.git",
+					Name:      "Project Name",
 				},
 			},
 		},


### PR DESCRIPTION
fix: pass target reference in registry share results [IAC-3286]
fix: duplicate scan

![image](https://github.com/user-attachments/assets/49b52d6e-378f-438b-966b-5d71e1bb2204)
