### PR TITLE
fix: replace git-urls [IAC-3320]

### DIFF
--- a/internal/git/parser.go
+++ b/internal/git/parser.go
@@ -1,0 +1,74 @@
+package git
+
+import (
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+var (
+	// (user)?@host:path.git
+	scpGithubUrlRegexp = regexp.MustCompile(`^(([\w._-]+)@)?([\w.-]+):(.*)$`)
+
+	validTransportSchemas = map[string]bool{
+		"ssh":     true,
+		"git":     true,
+		"git+ssh": true,
+		"http":    true,
+		"https":   true,
+		"ftp":     true,
+		"ftps":    true,
+		"rsync":   true,
+		"file":    true,
+	}
+)
+
+func ParseUrl(urlStr string) *url.URL {
+	// match standard URL & validate schema
+	parsedUrl, err := url.Parse(urlStr)
+	if err == nil && validTransportSchemas[parsedUrl.Scheme] {
+		return parsedUrl
+	}
+
+	// match SCP URL e.g. user@host:path
+	match := scpGithubUrlRegexp.FindStringSubmatch(urlStr)
+	if match == nil {
+		// no match for standard URL or SCP URL
+		// return a local URL
+		return &url.URL{
+			Scheme: "file",
+			Host:   "",
+			Path:   urlStr,
+		}
+	}
+
+	// if there's a match then we have the following data at indexes in match
+	// 0: full string
+	// 1: (\w+)@ match -> user
+	// 2: (\w+) match  -> user
+	// 3: ([\w.-]+) match -> host
+	// 4: (.*) -> path, can include query param
+
+	// get user info
+	var user *url.Userinfo
+	if match[2] != "" {
+		user = url.User(match[2])
+	}
+
+	// get query params
+	path, queryParams := match[4], ""
+	if strings.Contains(match[4], "?") {
+		strs := strings.Split(match[4], "?")
+		path = strs[0]
+		queryParams = strs[1]
+	}
+
+	// SCP URL with ssh scheme
+	return &url.URL{
+		Scheme:   "ssh",
+		User:     user,
+		Host:     match[3],
+		Path:     path,
+		RawQuery: queryParams,
+	}
+}

--- a/internal/git/parser_test.go
+++ b/internal/git/parser_test.go
@@ -1,0 +1,108 @@
+package git
+
+import (
+	"github.com/stretchr/testify/require"
+	"net/url"
+	"testing"
+)
+
+func TestParseUrl(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		output *url.URL
+	}{
+		{
+			name:   "unrecognised path - defaults to local url",
+			input:  "user@host",
+			output: &url.URL{Scheme: "file", Path: "user@host"},
+		},
+		{
+			name:   "user@host type of git origin url",
+			input:  "user@host.xz:path/to/repo.git/",
+			output: &url.URL{Scheme: "ssh", Host: "host.xz", Path: "path/to/repo.git/", User: url.User("user")},
+		},
+		{
+			name:   "host:path type of git origin url",
+			input:  "host.xz:/path/to/repo.git/",
+			output: &url.URL{Scheme: "ssh", Host: "host.xz", Path: "/path/to/repo.git/"},
+		},
+		{
+			name:   "git:// type of git origin url",
+			input:  "git://host.xz/path/to/repo.git/",
+			output: &url.URL{Scheme: "git", Host: "host.xz", Path: "/path/to/repo.git/"},
+		},
+		{
+			name:   "http git origin url",
+			input:  "http://host.xz/path/to/repo.git/",
+			output: &url.URL{Scheme: "http", Host: "host.xz", Path: "/path/to/repo.git/"},
+		},
+		{
+			name:   "https git origin url",
+			input:  "https://host.xz:1234/path/to/repo.git/",
+			output: &url.URL{Scheme: "https", Host: "host.xz:1234", Path: "/path/to/repo.git/"},
+		},
+		{
+			name:   "git@ type of git origin url",
+			input:  "git@host.xz:organization/repo.git?ref=test",
+			output: &url.URL{Scheme: "ssh", Host: "host.xz", Path: "organization/repo.git", User: url.User("git"), RawQuery: "ref=test"},
+		},
+		{
+			name:   "ssh type of git origin url",
+			input:  "ssh://host.xz:1234/path/to/repo.git/",
+			output: &url.URL{Scheme: "ssh", Host: "host.xz:1234", Path: "/path/to/repo.git/"},
+		},
+		{
+			name:   "ftp type of git origin url",
+			input:  "ftp://host.xz:1234/path/to/repo.git/",
+			output: &url.URL{Scheme: "ftp", Host: "host.xz:1234", Path: "/path/to/repo.git/"},
+		},
+		{
+			name:   "ftps type of git origin url",
+			input:  "ftps://host.xz/path/to/repo.git/",
+			output: &url.URL{Scheme: "ftps", Host: "host.xz", Path: "/path/to/repo.git/"},
+		},
+		{
+			name:   "file:// type of git origin url",
+			input:  "file:///path/to/repo.git/",
+			output: &url.URL{Scheme: "file", Path: "/path/to/repo.git/"},
+		},
+		{
+			name:   "file path type of git origin url",
+			input:  "/path/to/repo.git/",
+			output: &url.URL{Scheme: "file", Path: "/path/to/repo.git/"},
+		},
+		{
+			name:   "rsync:// type of git origin url",
+			input:  "rsync://host.xz/path/to/repo.git/",
+			output: &url.URL{Scheme: "rsync", Host: "host.xz", Path: "/path/to/repo.git/"},
+		},
+		{
+			name:   "git+ssh:// type of git origin url",
+			input:  "git+ssh://host.xz/path/to/repo.git/",
+			output: &url.URL{Scheme: "git+ssh", Host: "host.xz", Path: "/path/to/repo.git/"},
+		},
+		{
+			name:   "user@host/path of git origin url",
+			input:  "user-1@host.xz:path/to/repo.git/",
+			output: &url.URL{Scheme: "ssh", Host: "host.xz", Path: "path/to/repo.git/", User: url.User("user-1")},
+		},
+		{
+			name:   "user password url",
+			input:  "https://u:p@host.xz/organization/repo.git?ref=test",
+			output: &url.URL{Scheme: "https", Host: "host.xz", Path: "/organization/repo.git", RawQuery: "ref=test", User: url.UserPassword("u", "p")},
+		},
+		{
+			name:   "invalid git origin url",
+			input:  "some_invalid_string",
+			output: &url.URL{Scheme: "file", Path: "some_invalid_string"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := ParseUrl(test.input)
+			require.Equal(t, test.output, result)
+		})
+	}
+}

--- a/internal/processor/legacy/origin_url.go
+++ b/internal/processor/legacy/origin_url.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	giturls "github.com/whilp/git-urls"
+	"github.com/snyk/cli-extension-iac/internal/git"
 )
 
 // The function below is based on:
@@ -14,11 +14,7 @@ func formatOriginUrl(originUrl string) (string, error) {
 		return "", nil
 	}
 
-	parsedUrl, err := giturls.Parse(originUrl)
-	if err != nil {
-		return "", err
-	}
-
+	parsedUrl := git.ParseUrl(originUrl)
 	if parsedUrl.Host != "" && parsedUrl.Scheme != "" && isAllowedScheme(parsedUrl.Scheme) {
 		return fmt.Sprintf("%s://%s/%s", "http", strings.Trim(parsedUrl.Host, "/"), strings.Trim(parsedUrl.Path, "/")), nil
 	}

--- a/internal/processor/project_name.go
+++ b/internal/processor/project_name.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"regexp"
 
-	giturls "github.com/whilp/git-urls"
+	"github.com/snyk/cli-extension-iac/internal/git"
 )
 
 func (p *ResultsProcessor) readWorkingDirectoryName() (string, error) {
@@ -89,11 +89,7 @@ var (
 )
 
 func getProjectNameFromGitOriginUrl(url string) (string, error) {
-	gitURL, err := giturls.Parse(url)
-	if err != nil {
-		return "", err
-	}
-
+	gitURL := git.ParseUrl(url)
 	if match := azureDevOpsPathRegexp.FindStringSubmatch(gitURL.Path); match != nil {
 		return fmt.Sprintf("%s/%s/%s", match[1], match[2], match[3]), nil
 	}


### PR DESCRIPTION
Replace [git-urls](https://github.com/whilp/git-urls/blob/4a18977c6eecbf4ce0ca1e486e9ba77072ba4395/urls.go#L59) with our own implementation of git url parsing.

The vulnerability in git-urls was related to the regex expression used to match scp like urls, simplified the regex in our own implementation and ran snyk code against it to ensure no vulns have been added.

Jira ticket: https://snyksec.atlassian.net/browse/IAC-3320