### PR TITLE
feat: added usage tracking for IaCV2 [IAC-3308]

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/snyk/cli-extension-iac/internal/cloudapi"
 	"github.com/snyk/cli-extension-iac/internal/engine"
+	"github.com/snyk/cli-extension-iac/internal/registry"
 	"github.com/snyk/cli-extension-iac/internal/results"
 	"github.com/snyk/cli-extension-iac/internal/settings"
 )
@@ -48,6 +49,7 @@ type Command struct {
 	ResultsProcessor        ResultsProcessor
 	SnykCloudEnvironment    string
 	SnykClient              cloudapi.Client
+	RegistryClient          *registry.Client
 	Scan                    string
 	DetectionDepth          int
 	VarFile                 string
@@ -100,6 +102,16 @@ func (c Command) scan() scanOutput {
 
 	if !userSettings.Entitlements.InfrastructureAsCode {
 		return output.addScanErrors(errEntitlementInfrastructureAsCodeNotEnabled)
+	}
+
+	if c.IacNewEngine {
+		usage := c.RegistryClient.TrackUsage(ctx, userSettings.OrgPublicID)
+
+		if usage.TestLimitReached {
+			return output.addScanErrors(testLimitReached)
+		} else if usage.Err != nil {
+			c.Logger.Error().Err(usage.Err).Msg(unableToTrackUsage.Message)
+		}
 	}
 
 	paths, err := normalizePaths(c.Paths)

--- a/internal/command/errors.go
+++ b/internal/command/errors.go
@@ -52,6 +52,8 @@ const (
 	errorCodeNoLoadableInput
 	errorCodeFailedToMakeResourcesResolvers
 	errorCodeResourcesResolverError
+	errorCodeTestLimitReached
+	errorCodeUnableToTrackUsage
 )
 
 const (
@@ -99,6 +101,16 @@ var errEntitlementInfrastructureAsCodeNotEnabled = scanError{
 	Fields: map[string]any{
 		"entitlement": "infrastructureAsCode",
 	},
+}
+
+var testLimitReached = scanError{
+	Message: "test limit reached",
+	Code:    errorCodeTestLimitReached,
+}
+
+var unableToTrackUsage = scanError{
+	Message: "unable to track usage",
+	Code:    errorCodeUnableToTrackUsage,
 }
 
 var errReadSettings = scanError{

--- a/internal/commands/iactest/iactest.go
+++ b/internal/commands/iactest/iactest.go
@@ -197,6 +197,7 @@ func runNewEngine(ictx workflow.InvocationContext, inputPaths []string, cwd stri
 		ResultsProcessor:        &resultsProcessor,
 		SnykCloudEnvironment:    config.GetString(FlagSnykCloudEnvironment),
 		SnykClient:              cloudapiClient,
+		RegistryClient:          registryClient,
 		Scan:                    config.GetString(FlagScan),
 		DetectionDepth:          config.GetInt(FlagDepthDetection),
 		VarFile:                 config.GetString(FlagVarFile),

--- a/internal/registry/track_usage.go
+++ b/internal/registry/track_usage.go
@@ -1,0 +1,79 @@
+package registry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type TrackUsageData struct {
+	IsPrivate       bool `json:"isPrivate"`
+	IssuesPrevented int  `json:"issuesPrevented"`
+}
+
+type TrackUsageRequestBody struct {
+	Results []TrackUsageData `json:"results"`
+}
+
+type TrackUsageError struct {
+	TestLimitReached bool
+	Err              error
+}
+
+type TrackUsageResponse struct {
+	statusCode *int
+	err        error
+}
+
+func (c *Client) TrackUsage(ctx context.Context, org string) (outputErr TrackUsageError) {
+	trackUsageResponse := c.trackUsageRegistry(ctx, org)
+
+	switch *trackUsageResponse.statusCode {
+	case 200:
+		return TrackUsageError{false, nil}
+	case 429:
+		return TrackUsageError{true, nil}
+	default:
+		if trackUsageResponse.err != nil {
+			return TrackUsageError{false, trackUsageResponse.err}
+		}
+	}
+
+	return TrackUsageError{false, nil}
+}
+
+func (c *Client) trackUsageRegistry(ctx context.Context, org string) (response TrackUsageResponse) {
+	bodyData := []TrackUsageData{{true, 1}}
+	bodyResults := TrackUsageRequestBody{bodyData}
+
+	body, err := json.Marshal(bodyResults)
+	if err != nil {
+		return TrackUsageResponse{nil, fmt.Errorf("failed to marshal request body: %w", err)}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/v1/track-iac-usage/cli", c.url), bytes.NewBuffer(body))
+	if err != nil {
+		return TrackUsageResponse{nil, fmt.Errorf("create request: %v", err)}
+	}
+
+	query := req.URL.Query()
+	query.Set("org", org)
+	req.URL.RawQuery = query.Encode()
+
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return TrackUsageResponse{nil, fmt.Errorf("perform request: %v", err)}
+	}
+
+	defer func() {
+		if err := res.Body.Close(); err != nil && response.err == nil {
+			response.err = fmt.Errorf("close response body: %v", err)
+		}
+	}()
+
+	return TrackUsageResponse{&res.StatusCode, response.err}
+}


### PR DESCRIPTION
This change introduces usage tracking for IaCV2 scans.
A new `TrackUsage` method in the registry package now sends a request to the `/v1/track-iac-usage/cli` endpoint at the start of a scan. This is essential for gathering product analytics and for enforcing plan-based test limits.
The implementation correctly handles the 429 status code response from the API, ensuring that the scan is gracefully halted if an organization has reached its test limit..

Ticket: [IAC-3308](https://snyksec.atlassian.net/jira/software/c/projects/IAC/boards/301?selectedIssue=IAC-3308)

[IAC-3308]: https://snyksec.atlassian.net/browse/IAC-3308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ