### PR TITLE
feat(iac): support --exclude via param [IDE-1462]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 orbs:
   go: snyk/go@1.1.0
   prodsec: snyk/prodsec-orb@1
+  win: circleci/windows@5.0.0
 
 base_image: &base_image
   resource_class: small
@@ -10,11 +11,22 @@ base_image: &base_image
     - image: cimg/go:1.23
 
 jobs:
-  unit-test:
+  unit-test-linux:
     <<: *base_image
     steps:
       - checkout
       - run: go test ./...
+  unit-test-windows:
+    executor:
+      name: win/default
+      shell: powershell.exe -ExecutionPolicy Bypass
+    steps:
+      - checkout
+      - run: |
+          choco install golang --version=1.23.0 -y
+          refreshenv
+          go version
+          go test ./...
   lint:
     <<: *base_image
     resource_class: medium
@@ -48,7 +60,9 @@ workflows:
           name: Security Scans
           context:
             - analysis-iac
-      - unit-test:
-          name: Unit Test
+      - unit-test-linux:
+          name: Unit Test (Linux)
+      - unit-test-windows:
+          name: Unit Test (Windows)
       - lint:
           name: Linting

--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ snyk iac test --exclude=dir-to-skip,subdir/file.tf
 snyk iac test --exclude "dir-to-skip,subdir/file.tf"
 ```
 
-The exclusion is applied in addition to existing ignore mechanisms (such as `.gitignore` and `.snyk`).
+Only user-provided exclude patterns are applied by this flag.

--- a/README.md
+++ b/README.md
@@ -11,3 +11,14 @@ This module implements the Snyk CLI Extension for IaC workflows.
 ## Workflows
 
 - `snyk iac test`
+
+### Excluding files and directories
+
+You can exclude files or directories from IaC scans using the `--exclude` flag. The value is a comma-separated list of paths relative to the input directory. Both of the following are supported:
+
+```bash
+snyk iac test --exclude=dir-to-skip,subdir/file.tf
+snyk iac test --exclude "dir-to-skip,subdir/file.tf"
+```
+
+The exclusion is applied in addition to existing ignore mechanisms (such as `.gitignore` and `.snyk`).

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -401,15 +401,9 @@ func (c Command) applyExclusions(paths []string) ([]string, error) {
 			}
 		}
 
-		filter := utils.NewFileFilter(abs, c.Logger)
-
-		// Gather default rules from dotfiles
-		globs, err := filter.GetRules([]string{".gitignore", ".snyk"})
-		if err != nil {
-			return nil, err
-		}
-		// Append user-provided rules as absolute-globs based on root
-		globs = append(globs, buildUserGlobs(abs)...)
+        filter := utils.NewFileFilter(abs, c.Logger)
+        // Only use user-provided rules; do not include .gitignore or .snyk rules here
+        globs := buildUserGlobs(abs)
 
 		info, err := c.FS.Stat(abs)
 		if err != nil {

--- a/internal/command/exclude_integration_test.go
+++ b/internal/command/exclude_integration_test.go
@@ -1,0 +1,194 @@
+package command_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/cli-extension-iac/internal/command"
+	"github.com/snyk/cli-extension-iac/internal/engine"
+	"github.com/snyk/cli-extension-iac/internal/results"
+	"github.com/snyk/cli-extension-iac/internal/settings"
+)
+
+// Reuse mock types from command_test.go
+
+func TestExcludeFiltering_OSSingleRoot(t *testing.T) {
+	logger := zerolog.Nop()
+
+	workspace := t.TempDir()
+	withinDir(t, workspace)
+
+	// Create bundle file expected by command
+	require.NoError(t, os.WriteFile("bundle.tar.gz", nil, 0644))
+
+	// Create test tree
+	require.NoError(t, os.MkdirAll(filepath.Join("root", "a"), 0755))
+	require.NoError(t, os.MkdirAll(filepath.Join("root", "b"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join("root", "a", "file1.tf"), []byte(""), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join("root", "a", "keep.tf"), []byte(""), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join("root", "b", "file2.tf"), []byte(""), 0644))
+
+	capturedPaths := make([]string, 0)
+	policyEngine := mockEngine{
+		run: func(ctx context.Context, options engine.RunOptions) (*engine.Results, results.ScanAnalytics, []error, []error) {
+			capturedPaths = append(capturedPaths, options.Paths...)
+			return &engine.Results{}, results.ScanAnalytics{}, nil, nil
+		},
+	}
+	resultsProcessor := mockResultsProcessor{
+		processResults: func(rawResults *engine.Results, scanAnalytics results.ScanAnalytics) (*results.Results, error) {
+			return &results.Results{}, nil
+		},
+	}
+	userSettings := settings.Settings{Entitlements: settings.Entitlements{InfrastructureAsCode: true}}
+	settingsReader := readSettingsFunc(func(ctx context.Context) (*settings.Settings, error) { return &userSettings, nil })
+
+	cmd := command.Command{
+		FS:               afero.NewOsFs(),
+		Engine:           policyEngine,
+		Paths:            []string{filepath.Join("root")},
+		Bundle:           "bundle.tar.gz",
+		ResultsProcessor: resultsProcessor,
+		SettingsReader:   settingsReader,
+		Output:           outputFilePath,
+		Logger:           &logger,
+		Exclude:          []string{"b", filepath.ToSlash(filepath.Join("a", "file1.tf"))},
+	}
+
+	require.Equal(t, 0, cmd.Run())
+
+	// verify keep.tf included, excluded files absent
+	contains := func(s []string, needle string) bool {
+		for _, v := range s {
+			if v == needle {
+				return true
+			}
+		}
+		return false
+	}
+	require.True(t, contains(capturedPaths, filepath.ToSlash(filepath.Join("root", "a", "keep.tf"))))
+	require.False(t, contains(capturedPaths, filepath.ToSlash(filepath.Join("root", "b", "file2.tf"))))
+	require.False(t, contains(capturedPaths, filepath.ToSlash(filepath.Join("root", "a", "file1.tf"))))
+}
+
+func TestExcludeFiltering_OSMultiRoot(t *testing.T) {
+	logger := zerolog.Nop()
+	workspace := t.TempDir()
+	withinDir(t, workspace)
+	require.NoError(t, os.WriteFile("bundle.tar.gz", nil, 0644))
+
+	// Create two roots under the same workspace
+	for _, root := range []string{"root1", "root2"} {
+		require.NoError(t, os.MkdirAll(filepath.Join(root, "keep"), 0755))
+		require.NoError(t, os.MkdirAll(filepath.Join(root, "node_modules"), 0755))
+		require.NoError(t, os.MkdirAll(filepath.Join(root, ".terraform"), 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(root, "keep", "main.tf"), []byte(""), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(root, "node_modules", "ignore.tf"), []byte(""), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(root, ".terraform", "ignore.tf"), []byte(""), 0644))
+	}
+
+	capturedPaths := make([]string, 0)
+	policyEngine := mockEngine{
+		run: func(ctx context.Context, options engine.RunOptions) (*engine.Results, results.ScanAnalytics, []error, []error) {
+			capturedPaths = append(capturedPaths, options.Paths...)
+			return &engine.Results{}, results.ScanAnalytics{}, nil, nil
+		},
+	}
+	resultsProcessor := mockResultsProcessor{processResults: func(rawResults *engine.Results, scanAnalytics results.ScanAnalytics) (*results.Results, error) {
+		return &results.Results{}, nil
+	}}
+	userSettings := settings.Settings{Entitlements: settings.Entitlements{InfrastructureAsCode: true}}
+	settingsReader := readSettingsFunc(func(ctx context.Context) (*settings.Settings, error) { return &userSettings, nil })
+
+	cmd := command.Command{
+		FS:               afero.NewOsFs(),
+		Engine:           policyEngine,
+		Paths:            []string{"root1", "root2"},
+		Bundle:           "bundle.tar.gz",
+		ResultsProcessor: resultsProcessor,
+		SettingsReader:   settingsReader,
+		Output:           outputFilePath,
+		Logger:           &logger,
+		Exclude:          []string{"node_modules", ".terraform"},
+	}
+
+	require.Equal(t, 0, cmd.Run())
+
+	contains := func(needle string) bool {
+		for _, v := range capturedPaths {
+			if v == needle {
+				return true
+			}
+		}
+		return false
+	}
+	require.True(t, contains(filepath.ToSlash(filepath.Join("root1", "keep", "main.tf"))))
+	require.True(t, contains(filepath.ToSlash(filepath.Join("root2", "keep", "main.tf"))))
+	require.False(t, contains(filepath.ToSlash(filepath.Join("root1", "node_modules", "ignore.tf"))))
+	require.False(t, contains(filepath.ToSlash(filepath.Join("root2", ".terraform", "ignore.tf"))))
+}
+
+func TestExcludeFiltering_WindowsBackslashes(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-only backslash pattern test")
+	}
+	logger := zerolog.Nop()
+	workspace := t.TempDir()
+	withinDir(t, workspace)
+	require.NoError(t, os.WriteFile("bundle.tar.gz", nil, 0644))
+
+	require.NoError(t, os.MkdirAll(filepath.Join("root", "a"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join("root", "a", "file1.tf"), []byte(""), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join("root", "a", "keep.tf"), []byte(""), 0644))
+
+	capturedPaths := make([]string, 0)
+	policyEngine := mockEngine{run: func(ctx context.Context, options engine.RunOptions) (*engine.Results, results.ScanAnalytics, []error, []error) {
+		capturedPaths = append(capturedPaths, options.Paths...)
+		return &engine.Results{}, results.ScanAnalytics{}, nil, nil
+	}}
+	resultsProcessor := mockResultsProcessor{processResults: func(rawResults *engine.Results, scanAnalytics results.ScanAnalytics) (*results.Results, error) {
+		return &results.Results{}, nil
+	}}
+	userSettings := settings.Settings{Entitlements: settings.Entitlements{InfrastructureAsCode: true}}
+	settingsReader := readSettingsFunc(func(ctx context.Context) (*settings.Settings, error) { return &userSettings, nil })
+
+	cmd := command.Command{
+		FS:               afero.NewOsFs(),
+		Engine:           policyEngine,
+		Paths:            []string{"root"},
+		Bundle:           "bundle.tar.gz",
+		ResultsProcessor: resultsProcessor,
+		SettingsReader:   settingsReader,
+		Output:           outputFilePath,
+		Logger:           &logger,
+		Exclude:          []string{"a\\file1.tf"}, // backslash pattern
+	}
+
+	require.Equal(t, 0, cmd.Run())
+
+	contains := func(needle string) bool {
+		for _, v := range capturedPaths {
+			if v == needle {
+				return true
+			}
+		}
+		return false
+	}
+	require.True(t, contains(filepath.ToSlash(filepath.Join("root", "a", "keep.tf"))))
+	require.False(t, contains(filepath.ToSlash(filepath.Join("root", "a", "file1.tf"))))
+}
+
+func withinDir(t *testing.T, dir string) {
+	t.Helper()
+	prev, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+	require.NoError(t, os.Chdir(dir))
+}

--- a/internal/commands/iactest/flags.go
+++ b/internal/commands/iactest/flags.go
@@ -25,6 +25,7 @@ const (
 	FlagProjectLifecycle           = "project-lifecycle"
 	FlagProjectTags                = "project-tags"
 	FlagRules                      = "rules"
+	FlagExclude                    = "exclude"
 )
 
 func GetIaCTestFlagSet() *pflag.FlagSet {
@@ -58,6 +59,7 @@ func GetIaCTestFlagSet() *pflag.FlagSet {
 	flagSet.String(FlagProjectLifecycle, "", "Set the project lifecycle project attribute to one or more values (comma-separated).")
 	flagSet.String(FlagProjectTags, "", "Set the project tags to one or more values (comma-separated key value pairs with an \"=\" separator).")
 	flagSet.String(FlagRules, "", "Path to a directory containing custom rules.")
+	flagSet.String(FlagExclude, "", "Exclude files or directories from scan (comma-separated, relative to input directory).")
 
 	return flagSet
 }

--- a/internal/commands/iactest/iactest.go
+++ b/internal/commands/iactest/iactest.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/spf13/afero"
@@ -193,6 +194,7 @@ func runNewEngine(ictx workflow.InvocationContext, inputPaths []string, cwd stri
 		Engine:                  &policyEngine,
 		FS:                      fs,
 		Paths:                   inputPaths,
+		Exclude:                 parseExcludeFlag(config.GetString(FlagExclude)),
 		Bundle:                  config.GetString(RulesBundlePath),
 		ResultsProcessor:        &resultsProcessor,
 		SnykCloudEnvironment:    config.GetString(FlagSnykCloudEnvironment),
@@ -215,4 +217,19 @@ func runNewEngine(ictx workflow.InvocationContext, inputPaths []string, cwd stri
 	}
 
 	return outputFile, nil
+}
+
+func parseExcludeFlag(v string) []string {
+	if strings.TrimSpace(v) == "" {
+		return nil
+	}
+	parts := strings.Split(v, ",")
+	var out []string
+	for _, p := range parts {
+		s := strings.TrimSpace(p)
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
 }


### PR DESCRIPTION
- Add --exclude flag and wire to IaC new engine; - Apply only user-provided exclude patterns via go-application-framework FileFilter; - Add POSIX and Windows tests; - Update CircleCI (Linux + Windows); - Update README.